### PR TITLE
sc628, rpc-splitter test

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -35,7 +35,7 @@ ENV ORIGIN_THEGRAPH_URL=$SMOCKER \
  ORIGIN_POLONIEX_URL=$SMOCKER \
  ORIGIN_UPBIT_URL=$SMOCKER
 
-ENV ETH_RPC_URL=$SMOCKER
+ENV ETH_RPC_URL=http://127.0.0.1:8545
 
 # Installing setzer
 COPY ./libexec/setzer/ /root/setzer
@@ -48,4 +48,4 @@ COPY . /app
 WORKDIR /app/e2e
 RUN go mod download
 
-CMD ["go", "test", "-v", "-parallel", "1", "-cpu", "1", "./..."]
+CMD ["./scripts/test.sh"]

--- a/e2e/scripts/test.sh
+++ b/e2e/scripts/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+start_rpcsplitter() {
+    git clone https://github.com/chronicleprotocol/oracle-suite.git
+    cd oracle-suite
+    go mod download
+
+    timeout=2
+    endpoints="$SMOCKER,$SMOCKER,http://10.255.255.1"
+    (go run cmd/rpc-splitter/*.go run --log.format json --eth-rpc $endpoints -v debug -t $timeout)&
+    sleep 3
+    cd ..
+}
+
+start_rpcsplitter
+
+#export DEBUG=true
+printenv
+
+go test -v -parallel 1 -cpu 1 ./...


### PR DESCRIPTION
incorporate `rpc-splitter` with a timeout (non-addressable) IP. uses existing smocker mocks for eth rpc calls.