### PR TITLE
Fix runtime error (div by 0) on rethusd sources

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ coreutils, curl, jshon, bc, gnused, perl, datamash, git }:
 
 stdenv.mkDerivation rec {
   name = "setzer-mcd-${version}";
-  version = "0.6.0";
+  version = "0.6.1";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper];

--- a/libexec/setzer/setzer-price-rethusd
+++ b/libexec/setzer/setzer-price-rethusd
@@ -40,14 +40,18 @@ case $1 in
     setzer --format "$(bc -l <<<"$reth_wsteth * $wsteth_usd")"
   };;
   *) {
-    export SETZER_MIN_MEDIAN=2
-    reth_usd=$(setzer price rethusd rocketpool) # This is the reference price
-    price=$(setzer --price-commands "-$1-" $pair "${sources[@]}")
-    # NOTE: Deviation is the percent difference between the RocketPool
-    # price and market price. Sign is removed so deviation in either direction,
-    # positive or negative, will trigger the circuit breaker.
-    deviation=$(echo "1 - $reth_usd / $price" | bc -l | sed 's/-//')
-    circuit_breaker $deviation
-    echo "$price"
+    if [[ -z "$1" || "$1" = "median" ]]; then
+        export SETZER_MIN_MEDIAN=2
+        reth_usd=$(setzer price rethusd rocketpool) # This is the reference price
+        price=$(setzer --price-commands "-$1-" $pair "${sources[@]}")
+        # NOTE: Deviation is the percent difference between the RocketPool
+        # price and market price. Sign is removed so deviation in either direction,
+        # positive or negative, will trigger the circuit breaker.
+        deviation=$(echo "1 - $reth_usd / $price" | bc -l | sed 's/-//')
+        circuit_breaker $deviation
+        echo "$price"
+    else
+        setzer --price-commands "-$1-" $pair "${sources[@]}"
+    fi
   };;
 esac


### PR DESCRIPTION
discovered this somewhat benign error when troubleshooting rethusd circuit breaker. `price-commands` does not always return a numeric value, and the rethusd price wasn't accounting for that.